### PR TITLE
Add chat type options to StartChatScreen

### DIFF
--- a/app/src/main/java/com/lavie/randochat/ui/screen/StartChatScreen.kt
+++ b/app/src/main/java/com/lavie/randochat/ui/screen/StartChatScreen.kt
@@ -2,31 +2,26 @@ package com.lavie.randochat.ui.screen
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.MailOutline
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lavie.randochat.R
 import com.lavie.randochat.ui.component.CustomSpacer
 import com.lavie.randochat.ui.component.customToast
 import com.lavie.randochat.ui.theme.Dimens
+import com.lavie.randochat.ui.theme.Dimens.baseMargin
+import com.lavie.randochat.ui.theme.Dimens.buttonRadius
+import com.lavie.randochat.ui.theme.Dimens.textFieldHeight
 import com.lavie.randochat.utils.ChatType
 import com.lavie.randochat.utils.Constants
 import com.lavie.randochat.utils.singleClickHandler
@@ -45,8 +40,7 @@ fun StartChatScreen(
     val myUserId = myUser?.id
     val context = LocalContext.current
 
-    //TODO Need to get value from user choice
-    val chatType: ChatType = ChatType.RANDOM
+    var chatType by remember { mutableStateOf(ChatType.RANDOM) }
 
     val activity = context as? Activity
 
@@ -55,43 +49,70 @@ fun StartChatScreen(
     }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = Dimens.baseMarginDouble),
+        verticalArrangement = Arrangement.SpaceBetween,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Icon(
-            imageVector = Icons.Outlined.MailOutline,
-            contentDescription = null,
-            modifier = Modifier.size(Dimens.mailIcon),
-            tint = Color(0xFFD8D8D8)
-        )
+        CustomSpacer(height = Dimens.baseMarginDouble)
 
-        CustomSpacer(height = Dimens.baseSpacerHeight)
+        Icon(
+            painter = painterResource(id = R.drawable.vector_logo),
+            contentDescription = null,
+            tint = Color.Unspecified,
+            modifier = Modifier.size(80.dp)
+        )
 
         Text(
-            fontSize = Dimens.welcomeTextSize,
-            fontWeight = FontWeight.Medium,
+            text = stringResource(R.string.welcome_to_rando_chat),
+            style = MaterialTheme.typography.titleLarge,
             color = Color.Black,
-            text = stringResource(R.string.lets_start_chatting)
+            modifier = Modifier.padding(top = baseMargin)
         )
 
-        CustomSpacer(height = Dimens.baseSpacerHeight)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center
+        ) {
+            ChatType.values().forEach { type ->
+                val label = when (type) {
+                    ChatType.RANDOM -> stringResource(R.string.global_random_chat)
+                    ChatType.LOCATION -> stringResource(R.string.chat_nearby)
+                    ChatType.AGE -> stringResource(R.string.chat_by_age)
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = baseMargin)
+                ) {
+                    RadioButton(
+                        selected = chatType == type,
+                        onClick = { chatType = type }
+                    )
+                    Spacer(modifier = Modifier.width(baseMargin))
+                    Text(text = label, style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+        }
 
-        TextButton(
+        Button(
             onClick = singleClickHandler {
                 if (myUserId != null) {
                     navController.navigate("${Constants.SPLASH_SCREEN}/${Constants.SPLASH_MODE_MATCHING}/${R.string.matching}")
                     matchViewModel.startMatching(myUserId, chatType)
                 }
-            }
-        )
-        {
-            Text(
-                text = stringResource(R.string.start_a_chat),
-                style = MaterialTheme.typography.titleMedium,
-                color = Color(0xFF2979FF)
-            )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(textFieldHeight),
+            shape = RoundedCornerShape(buttonRadius)
+        ) {
+            Text(text = stringResource(R.string.start_matching))
         }
+
+        CustomSpacer(height = Dimens.baseMarginDouble)
     }
 
     LaunchedEffect(matchState) {

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -71,4 +71,9 @@
     <string name="welcome_notice">
         Chào mừng đến với Rando Chat! Đây là nền tảng trò chuyện với người lạ. Vì sự an toàn của bạn, không nên cung cấp thông tin cá nhân nhạy cảm và hãy luôn tôn trọng người trò chuyện cùng. Mọi hành vi thô tục, quấy rối đều bị nghiêm cấm.
     </string>
+    <string name="welcome_to_rando_chat">Chào mừng đến với Rando Chat!</string>
+    <string name="global_random_chat">Chat ngẫu nhiên toàn cầu</string>
+    <string name="chat_nearby">Chat gần bạn</string>
+    <string name="chat_by_age">Chat theo độ tuổi</string>
+    <string name="start_matching">Bắt đầu ghép đôi</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,5 +72,10 @@
     <string name="welcome_notice">
         Welcome to Rando Chat! You are about to chat with strangers. For your safety, do not share sensitive personal information and always respect your chat partner. Any inappropriate or abusive behavior is strictly prohibited.
     </string>
+    <string name="welcome_to_rando_chat">Welcome to Rando Chat!</string>
+    <string name="global_random_chat">Global random chat</string>
+    <string name="chat_nearby">Chat nearby</string>
+    <string name="chat_by_age">Chat by age</string>
+    <string name="start_matching">Start Matching</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- show RandoChat logo and heading on StartChatScreen
- let user choose chat type (random, nearby, by age)
- add `Start Matching` button
- provide new string resources in English and Vietnamese

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687252e76c54832ba0d2ae8f5f0d1bb2