### PR TITLE
Add scaffold to ChatScreen

### DIFF
--- a/app/src/main/java/com/lavie/randochat/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/lavie/randochat/ui/navigation/AppNavHost.kt
@@ -53,7 +53,7 @@ fun AppNavHost(authViewModel: AuthViewModel) {
         ) { backStackEntry ->
             val roomId = backStackEntry.arguments?.getString(Constants.ROOM_ID)
             if (roomId != null) {
-                ChatScreen(chatViewModel, authViewModel, roomId)
+                ChatScreen(navController, chatViewModel, authViewModel, roomId)
             }
         }
 

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -69,6 +69,8 @@
     <string name="message_sent">Đã gửi</string>
     <string name="message_seen">Đã xem</string>
     <string name="typing">Đang nhập…</string>
+    <string name="chat_random">Chat Random</string>
+    <string name="settings">Cài đặt</string>
     <string name="welcome_notice">
         Chào mừng đến với Rando Chat! Đây là nền tảng trò chuyện với người lạ. Vì sự an toàn của bạn, không nên cung cấp thông tin cá nhân nhạy cảm và hãy luôn tôn trọng người trò chuyện cùng. Mọi hành vi thô tục, quấy rối đều bị nghiêm cấm.
     </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,8 @@
     <string name="message_sent">Sent</string>
     <string name="message_seen">Seen</string>
     <string name="typing">Typing…</string>
+    <string name="chat_random">Chat Random</string>
+    <string name="settings">Settings</string>
     <string name="welcome_notice">
         Welcome to Rando Chat! You are about to chat with strangers. For your safety, do not share sensitive personal information and always respect your chat partner. Any inappropriate or abusive behavior is strictly prohibited.
     </string>


### PR DESCRIPTION
## Summary
- refactor `ChatScreen` with a `Scaffold`
- add top app bar with settings button
- move input bar into bottom bar
- update navigation to pass `NavController`
- add string resources for header

## Testing
- `./gradlew lintVitalRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687396fa969c832b8f2d8328956481c0