### PR TITLE
Add emoji picker

### DIFF
--- a/app/src/main/java/com/lavie/randochat/ui/component/ChatInputBar.kt
+++ b/app/src/main/java/com/lavie/randochat/ui/component/ChatInputBar.kt
@@ -74,6 +74,7 @@ fun ChatInputBar(
     var startTime by remember { mutableStateOf(System.currentTimeMillis()) }
     var currentTime by remember { mutableStateOf(startTime) }
     var menuExpanded by remember { mutableStateOf(false) }
+    var emojiExpanded by remember { mutableStateOf(false) }
     remember { mutableStateOf(false) }
 
     LaunchedEffect(voiceRecordState) {
@@ -365,6 +366,46 @@ fun ChatInputBar(
                             .padding(end = Dimens.baseMargin)
                             .width(Dimens.baseIconSize)
                     )
+
+                    Box(
+                        modifier = Modifier
+                            .padding(end = Dimens.baseMargin)
+                            .align(Alignment.CenterVertically)
+                    ) {
+                        ImageButton(
+                            onClick = { emojiExpanded = true },
+                            vectorId = R.drawable.vector_emoji_icon,
+                            modifier = Modifier.width(Dimens.baseIconSize)
+                        )
+
+                        DropdownMenu(
+                            expanded = emojiExpanded,
+                            onDismissRequest = { emojiExpanded = false },
+                            modifier = Modifier.background(MaterialTheme.colorScheme.surface)
+                        ) {
+                            DropdownMenuItem(
+                                text = { Icon(painterResource(R.drawable.vector_emoji_smile), contentDescription = null) },
+                                onClick = {
+                                    emojiExpanded = false
+                                    onValueChange(value + "\uD83D\uDE04")
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Icon(painterResource(R.drawable.vector_emoji_people), contentDescription = null) },
+                                onClick = {
+                                    emojiExpanded = false
+                                    onValueChange(value + "\uD83E\uDD73")
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Icon(painterResource(R.drawable.vector_emoji_food), contentDescription = null) },
+                                onClick = {
+                                    emojiExpanded = false
+                                    onValueChange(value + "\uD83C\uDF54")
+                                }
+                            )
+                        }
+                    }
 
                     CustomChatTextField(
                         value = value,

--- a/app/src/main/res/drawable/vector_emoji_food.xml
+++ b/app/src/main/res/drawable/vector_emoji_food.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M20,3H9v2.4l1.81,1.45C10.93,6.94,11,7.09,11,7.24v4.26c0,0.28-0.22,0.5-0.5,0.5h-4C6.22,12,6,11.78,6,11.5V7.24c0-0.15,0.07-0.3,0.19-0.39L8,5.4V3H4v10c0,2.21,1.79,4,4,4h6c2.21,0,4-1.79,4-4v-3h2c1.11,0,2-0.9,2-2V5C22,3.89,21.11,3,20,3z M20,8h-2V5h2V8z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4,19h16v2H4V19z" />
+</vector>

--- a/app/src/main/res/drawable/vector_emoji_icon.xml
+++ b/app/src/main/res/drawable/vector_emoji_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11.99,2C6.47,2,2,6.48,2,12c0,5.52,4.47,10,9.99,10C17.52,22,22,17.52,22,12C22,6.48,17.52,2,11.99,2z M8.5,8C9.33,8,10,8.67,10,9.5S9.33,11,8.5,11S7,10.33,7,9.5S7.67,8,8.5,8z M12,18c-2.28,0-4.22-1.66-5-4h10C16.22,16.34,14.28,18,12,18z M15.5,11c-0.83,0-1.5-0.67-1.5-1.5S14.67,8,15.5,8S17,8.67,17,9.5S16.33,11,15.5,11z" />
+</vector>

--- a/app/src/main/res/drawable/vector_emoji_people.xml
+++ b/app/src/main/res/drawable/vector_emoji_people.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,4A2,2 0 0,0 10,6A2,2 0 0,0 12,8A2,2 0 0,0 14,6A2,2 0 0,0 12,4M15.89,8.11C15.5,7.72 14.83,7 13.53,7C13.32,7 12.11,7 11,7C8.24,6.99 6,4.75 6,2H4C4,5.16 6.11,7.84 9,8.71V22H11V16H13V22H15V10.05L18.95,14L20.36,12.59L15.89,8.11Z" />
+</vector>

--- a/app/src/main/res/drawable/vector_emoji_smile.xml
+++ b/app/src/main/res/drawable/vector_emoji_smile.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11.99,2C6.47,2,2,6.48,2,12c0,5.52,4.47,10,9.99,10C17.52,22,22,17.52,22,12C22,6.48,17.52,2,11.99,2z M8.5,8C9.33,8,10,8.67,10,9.5S9.33,11,8.5,11S7,10.33,7,9.5S7.67,8,8.5,8z M12,18c-2.28,0-4.22-1.66-5-4h10C16.22,16.34,14.28,18,12,18z M15.5,11c-0.83,0-1.5-0.67-1.5-1.5S14.67,8,15.5,8S17,8.67,17,9.5S16.33,11,15.5,11z" />
+</vector>


### PR DESCRIPTION
## Summary
- add vector assets for emoji icons
- implement emoji dropdown in `ChatInputBar`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6885c8f59ef0832b989b93aa35cdcb5f